### PR TITLE
feat: ingore upgrade feature for version command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+# [3.16.7](https://github.com/serverless/serverless-tencent/compare/v3.16.6...v3.16.7) (2021-12-07)
+
+- Ignore upgrade feature for `version` command
+
 # [3.16.6](https://github.com/serverless/serverless-tencent/compare/v3.16.5...v3.16.6) (2021-12-06)
 
 - We consider `macos_x64` as `mac_arm64` right now and provide this standalone to `mac arm64` users, due to Github CI has not provide a `mac arm64` environment to build standalone

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-tencent",
-  "version": "3.16.6",
+  "version": "3.16.7",
   "description": "Serverless Tencent command line tool",
   "main": "./dist/index.js",
   "repository": "serverless/serverless-tencent",

--- a/src/index.js
+++ b/src/index.js
@@ -36,10 +36,10 @@ module.exports = async () => {
     }
 
     /*
-     * 1. Do not check the CLI upgrade for deploy command
+     * 1. Do not check the CLI upgrade for deploy, version commands
      * 2. Process standaloneUpgrade function for dev command in the closeHandler callback
      */
-    if (!['deploy', 'dev'].includes(command)) {
+    if (!['deploy', 'dev', 'version'].includes(command)) {
       await standaloneUpgrade(config);
     }
   } catch (error) {


### PR DESCRIPTION
`Framework CLI` can use `serverelss-tencent version(-v, --version)` to  get the version message and output for `serverless -v`, so cli does not need to detect the upgrade for `version` command. 
<img width="645" alt="Screen Shot 2021-12-07 at 18 07 30" src="https://user-images.githubusercontent.com/11454175/145009304-5acf78a8-8d44-4e77-8d3c-70543290cb7d.png">
