### PR TITLE
Improve Tencent CLI integraton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file. See [standa
 # [3.16.8](https://github.com/serverless/serverless-tencent/compare/v3.16.7...v3.16.8) (2021-12-07)
 
 - Show plain version message by `serverless-tencent version --plain`
+- `--skip-update` option can skip `auto upgrade feature`
+- Use `$HOME/.serverless-tencent` as **CLI resource path**
 
 # [3.16.7](https://github.com/serverless/serverless-tencent/compare/v3.16.6...v3.16.7) (2021-12-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+# [3.16.8](https://github.com/serverless/serverless-tencent/compare/v3.16.7...v3.16.8) (2021-12-07)
+
+- Show plain version message by `serverless-tencent version --plain`
+
 # [3.16.7](https://github.com/serverless/serverless-tencent/compare/v3.16.6...v3.16.7) (2021-12-07)
 
 - Ignore upgrade feature for `version` command

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-tencent",
-  "version": "3.16.7",
+  "version": "3.16.8",
   "description": "Serverless Tencent command line tool",
   "main": "./dist/index.js",
   "repository": "serverless/serverless-tencent",

--- a/src/commands/credentials.js
+++ b/src/commands/credentials.js
@@ -26,7 +26,7 @@ const {
   ServerlessCLIError,
 } = require('../libs/utils');
 
-const globalTencentCredentials = path.join(os.homedir(), '.serverless/tencent/credentials');
+const globalTencentCredentials = path.join(os.homedir(), '.serverless-tencent/credentials');
 
 module.exports = async (config, cli) => {
   const subCommand = config.params[0];

--- a/src/commands/version.js
+++ b/src/commands/version.js
@@ -3,7 +3,12 @@
 /*
  * serverless-tencent: Command: RUN
  */
+const { version } = require('../../package.json');
 
-module.exports = (_, cli) => {
+module.exports = (config, cli) => {
+  if (config.plain) {
+    console.log(version);
+    return;
+  }
   cli.logVersion();
 };

--- a/src/index.js
+++ b/src/index.js
@@ -37,9 +37,10 @@ module.exports = async () => {
 
     /*
      * 1. Do not check the CLI upgrade for deploy, version commands
-     * 2. Process standaloneUpgrade function for dev command in the closeHandler callback
+     * 2. Skip update with --skip-update option
+     * 3. Process standaloneUpgrade function for dev command in the closeHandler callback
      */
-    if (!['deploy', 'dev', 'version'].includes(command)) {
+    if (!config['skip-update'] && !['deploy', 'dev', 'version'].includes(command)) {
       await standaloneUpgrade(config);
     }
   } catch (error) {

--- a/src/libs/telemtry/cache-path.js
+++ b/src/libs/telemtry/cache-path.js
@@ -6,5 +6,5 @@ const os = require('os');
 module.exports = (() => {
   const resolvedHomeDir = os.homedir();
   if (!resolvedHomeDir) return null;
-  return path.resolve(resolvedHomeDir, '.serverless', 'tencent', 'telemetry-cache');
+  return path.resolve(resolvedHomeDir, '.serverless-tencent', 'telemtry-cache');
 })();

--- a/src/libs/utils/basic.js
+++ b/src/libs/utils/basic.js
@@ -776,7 +776,7 @@ const parseCliInputs = () => {
 const loadTencentGlobalConfig = (
   cli,
   config = {},
-  credentialsPath = path.join(os.homedir(), '.serverless/tencent/credentials')
+  credentialsPath = path.join(os.homedir(), '.serverless-tencent/credentials')
 ) => {
   // Users do not want to use global credentials
   if (config.login) {

--- a/src/libs/utils/utils.js
+++ b/src/libs/utils/utils.js
@@ -555,7 +555,7 @@ inputs:
   return getEggYML();
 };
 
-const clientUidDefaultPath = path.join(os.homedir(), '.serverless/tencent/client_uid-credentials');
+const clientUidDefaultPath = path.join(os.homedir(), '.serverless-tencent/client_uid-credentials');
 // If current machine does not have an uuid, create and save it, or load  and finally return the value.
 const writeClientUid = async (p = clientUidDefaultPath, options = {}) => {
   let res = {};


### PR DESCRIPTION
Close: https://app.asana.com/0/1200011502754281/1201480014137065/f
---
1. Add `--plain` options for `version` command. <img width="572" alt="Screen Shot 2021-12-07 at 19 41 22" src="https://user-images.githubusercontent.com/11454175/145022998-a6223439-71f0-4de3-9109-694fe0d49b75.png">
2. Change `CLI resource path` to `$HOME/.serverless-tencent`.
3. `--skip-update` option to skip `auto upgrade sandalone` feature
