### PR TITLE
fix: windows upgrade issue, imporve CLI animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. See [standa
 - Improve standalone ugprade animation
 - The user will not be reminded to upgrade again within seven days after the user chooses not to upgrade.
 - Fix standalone upgrade issue on windows
+- Output detail for `version` command with `binary` or `npm`
 
 # [3.19.2](https://github.com/serverless/serverless-tencent/compare/v3.19.1...v3.19.2) (2022-01-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+# [3.19.3](https://github.com/serverless/serverless-tencent/compare/v3.19.2...v3.19.3) (2022-01-20)
+
+- `help` command will not trigger standalone upgrade
+- Improve standalone ugprade animation
+- The user will not be reminded to upgrade again within seven days after the user chooses not to upgrade.
+- Fix standalone upgrade issue on windows
+
 # [3.19.2](https://github.com/serverless/serverless-tencent/compare/v3.19.1...v3.19.2) (2022-01-20)
 
 - Fix standalone upgrade on windows

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-tencent",
-  "version": "3.19.2",
+  "version": "3.19.3",
   "description": "Serverless Tencent command line tool",
   "main": "./dist/index.js",
   "repository": "serverless/serverless-tencent",
@@ -61,6 +61,7 @@
     "child-process-ext": "^2.1.1",
     "chokidar": "^3.5.1",
     "ci-info": "^3.2.0",
+    "cli-progress-footer": "^2.3.0",
     "dayjs": "^1.10.4",
     "dotenv": "^8.2.0",
     "fastest-levenshtein": "^1.0.12",

--- a/src/commands/version.js
+++ b/src/commands/version.js
@@ -7,7 +7,7 @@ const { version } = require('../../package.json');
 
 module.exports = (config, cli) => {
   if (config.plain) {
-    console.log(version);
+    console.log(`${version}(${process.pkg ? 'Binary' : 'npm'})`);
     return;
   }
   cli.logVersion();

--- a/src/index.js
+++ b/src/index.js
@@ -36,11 +36,11 @@ module.exports = async () => {
     }
 
     /*
-     * 1. Do not check the CLI upgrade for deploy, version commands
+     * 1. Do not check the CLI upgrade for deploy, version, help commands
      * 2. Skip update with --skipUpdate option
      * 3. Process standaloneUpgrade function for dev command in the closeHandler callback
      */
-    if (!config.skipUpdate && !['deploy', 'dev', 'version'].includes(command)) {
+    if (!config.skipUpdate && !['deploy', 'dev', 'version', 'help'].includes(command)) {
       await standaloneUpgrade(config);
     }
   } catch (error) {

--- a/src/libs/cli.js
+++ b/src/libs/cli.js
@@ -471,7 +471,7 @@ TraceId:     ${traceId}`;
   logVersion() {
     this.logLogo();
     this.log();
-    this.log(`serverless - tencent version: ${version} `);
+    this.log(`serverless - tencent version: ${version}(${process.pkg ? 'Binary' : 'npm'})`);
     this.log();
   }
 

--- a/src/libs/utils/constants.js
+++ b/src/libs/utils/constants.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const os = require('os');
+
+const USER_PERFERENCE_FILE = `${os.homedir}/.serverless-tencent/perference.json`;
+
+module.exports = {
+  USER_PERFERENCE_FILE,
+};

--- a/src/libs/utils/index.js
+++ b/src/libs/utils/index.js
@@ -2,8 +2,10 @@
 
 const basic = require('./basic');
 const utils = require('./utils');
+const constants = require('./constants');
 
 module.exports = {
   ...basic,
   ...utils,
+  ...constants,
 };

--- a/src/libs/utils/utils.js
+++ b/src/libs/utils/utils.js
@@ -16,11 +16,13 @@ const {
   resolveVariables,
   parseCliInputs,
   fileExists,
+  readAndParseSync,
 } = require('./basic');
 const { mergeDeepRight } = require('ramda');
 const YAML = require('js-yaml');
 const fse = require('fs-extra');
 const inquirer = require('@serverless/utils/inquirer');
+const { USER_PERFERENCE_FILE } = require('./constants');
 
 const updateEnvFile = (envs) => {
   // write env file
@@ -602,6 +604,16 @@ class ServerlessCLIError extends Error {
   }
 }
 
+// quickly write to user's new perference data to USER_PERFERENCE_FILE
+const writePerference = async (newPerference = {}) => {
+  let newData = newPerference;
+  if (await fileExists(USER_PERFERENCE_FILE)) {
+    const data = readAndParseSync(USER_PERFERENCE_FILE);
+    newData = { ...data, ...newData };
+  }
+  await fse.writeFile(USER_PERFERENCE_FILE, JSON.stringify(newData, null, 2));
+};
+
 module.exports = {
   loadInstanceCredentials,
   login,
@@ -619,4 +631,5 @@ module.exports = {
   clientUidDefaultPath,
   loadTencentInstanceConfig,
   ServerlessCLIError,
+  writePerference,
 };

--- a/tests/commands/version.test.js
+++ b/tests/commands/version.test.js
@@ -13,7 +13,7 @@ describe('Test sls version command: src/commands/version', () => {
   });
   test('output plain version', () => {
     versionCmd({ plain: true }, {});
-    expect(console.log.mock.calls[0][0]).toBe(version);
+    expect(console.log.mock.calls[0][0]).toBe(`${version}(${process.pkg ? 'Binary' : 'npm'})`);
   });
   test('output more content version', () => {
     const cli = new CLI({});
@@ -23,6 +23,8 @@ describe('Test sls version command: src/commands/version', () => {
       (data) => (stdoutData += data),
       () => versionCmd({}, cli)
     );
-    expect(stdoutData).toMatch(`serverless - tencent version: ${version}`);
+    expect(stdoutData).toMatch(
+      `serverless - tencent version: ${version}(${process.pkg ? 'Binary' : 'npm'})`
+    );
   });
 });


### PR DESCRIPTION
Closes:
1. https://app.asana.com/0/1200011502754281/1201686716747343/f
2. https://app.asana.com/0/1200011502754281/1201686716747348/f
3. https://app.asana.com/0/1200011502754281/1201690730892296/f
4. https://app.asana.com/0/1200011502754281/1201690798244810/f
---
### help 命令不提示升级
`sls info` 命令之后提示升级，说明本地的binary需要更新: 
<img width="1017" alt="Screen Shot 2022-01-20 at 21 30 00" src="https://user-images.githubusercontent.com/11454175/150348170-8f7e06b8-e478-4b5c-ba61-b7da20fd1dbe.png">
`sls --help, sls xxx --help` 均不会提示升级
<img width="932" alt="Screen Shot 2022-01-20 at 21 30 57" src="https://user-images.githubusercontent.com/11454175/150348229-3229a606-e1ec-4dba-9e0a-e2d210e8cdc2.png">

### 升级信息前添加动画
<img width="477" alt="Screen Shot 2022-01-20 at 21 32 14" src="https://user-images.githubusercontent.com/11454175/150348424-5c70f4d0-f131-4d7b-83d8-23ff6d451cfe.png">

### 升级之后 ，使用 **升级成功** 代替原信息
<img width="594" alt="Screen Shot 2022-01-20 at 21 32 35" src="https://user-images.githubusercontent.com/11454175/150348620-f153ec3b-6494-41b7-b95e-d4bafe8f9127.png">

### 用户选择不升级之后，7天之内不再次提醒升级

第一次选择了 **no**, 第二次不展示升级
<img width="1018" alt="Screen Shot 2022-01-20 at 21 35 18" src="https://user-images.githubusercontent.com/11454175/150348884-ba786a4c-d9a1-4363-a082-73f1db7e3a7c.png">

将用户**放弃升级**的时刻记录在 `~/.serverless-tencnet/upgrade_expire.txt` 中，保证7天之内不再次提醒，下面的截图是我将时间改为7天之前，这样用户会再次收到新的升级提醒
<img width="1028" alt="Screen Shot 2022-01-20 at 21 38 49" src="https://user-images.githubusercontent.com/11454175/150349390-6505f217-bc9b-41e7-8eb9-eb361510cc63.png">

