### PR TITLE
Enable users to choose local and global credentials

### DIFF
--- a/src/libs/auto.js
+++ b/src/libs/auto.js
@@ -333,7 +333,20 @@ module.exports = async () => {
           }
         }
 
-        const { instances } = await sdk.listInstances();
+        let instances = [];
+        try {
+          instances = await sdk.listInstances();
+        } catch (error) {
+          cli.logError(
+            {
+              message: '无法获取用户应用信息，请检查授权信息后重试',
+              step: '获取用户应用信息',
+              source: 'Serverless::CLI',
+            },
+            { command: 'auto' }
+          );
+          process.exit();
+        }
         if (Array.isArray(instances) && instances.length > 0) {
           isLinkingInstance = true;
           const appNames = instances.reduce((acc, cur) => {


### PR DESCRIPTION
## What has been implemented?

Closes https://app.asana.com/0/1200011502754281/1201686716747357


## Screenshots
1. 选择 profile
<img width="512" alt="Screen Shot 2022-01-27 at 2 00 23 PM" src="https://user-images.githubusercontent.com/5512552/151304936-57b0d2a4-bda5-4856-b0f1-002cb96a2527.png">

2. 选择对应 profile 需要关联的应用
<img width="529" alt="Screen Shot 2022-01-27 at 2 03 18 PM" src="https://user-images.githubusercontent.com/5512552/151304941-ebc626ae-a62c-48ed-92a0-9e24f0c65b07.png">

3. 身份校验错误或获取应用信息失败
<img width="586" alt="Screen Shot 2022-01-27 at 2 35 25 PM" src="https://user-images.githubusercontent.com/5512552/151304945-e86ac0e2-e9f4-4b2b-8efa-a787537d2163.png">

