### PR TITLE
feat: add metrics for standalone upgrade

### DIFF
--- a/src/libs/standalone.js
+++ b/src/libs/standalone.js
@@ -124,7 +124,7 @@ const standaloneUpgrade = async (options) => {
     cliProgressFooter.progressAnimationPrefixFrames.map((frame) => `\x1b[93m${frame}\x1b[39m`);
 
   const standaloneTelemetryPayload = await generatePayload({
-    command: 'standaloneUpgrade'
+    command: 'upgrade',
   });
 
   try {
@@ -172,12 +172,15 @@ const standaloneUpgrade = async (options) => {
     console.log(red(`升级失败: ${e.message}`));
 
     e.source = 'Serverless::CLI';
-    e.step = 'CLI升级standalone';
-    await storeLocally({
-      ...standaloneTelemetryPayload,
-      outcome: 'failure',
-      failure_reason: e.message,
-    }, e);
+    e.step = '升级命令行';
+    await storeLocally(
+      {
+        ...standaloneTelemetryPayload,
+        outcome: 'failure',
+        failure_reason: e.message,
+      },
+      e
+    );
 
     process.exit(-1);
   } finally {

--- a/src/libs/standalone.js
+++ b/src/libs/standalone.js
@@ -17,6 +17,7 @@ const { promisify } = require('util');
 const pipeline = promisify(stream.pipeline);
 const confirm = require('@serverless/utils/inquirer/confirm');
 const { readAndParseSync, USER_PERFERENCE_FILE, writePerference } = require('./utils');
+const { storeLocally, generatePayload } = require('./telemtry');
 
 const BINARY_TMP_PATH = path.resolve(os.tmpdir(), 'serverless-tencent-binary-tmp');
 const BINARY_PATH = `${os.homedir()}/.serverless-tencent/bin/serverless-tencent${
@@ -122,6 +123,10 @@ const standaloneUpgrade = async (options) => {
   cliProgressFooter.progressAnimationPrefixFrames =
     cliProgressFooter.progressAnimationPrefixFrames.map((frame) => `\x1b[93m${frame}\x1b[39m`);
 
+  const standaloneTelemetryPayload = await generatePayload({
+    command: 'standaloneUpgrade'
+  });
+
   try {
     // For auto upgrade situation, need users to confirm the upgrade, or it will skip after 5s
     let answer;
@@ -162,8 +167,18 @@ const standaloneUpgrade = async (options) => {
     await fsp.chmod(BINARY_PATH, 0o755);
 
     console.log('\n升级成功');
+    await storeLocally(standaloneTelemetryPayload);
   } catch (e) {
     console.log(red(`升级失败: ${e.message}`));
+
+    e.source = 'Serverless::CLI';
+    e.step = 'CLI升级standalone';
+    await storeLocally({
+      ...standaloneTelemetryPayload,
+      outcome: 'failure',
+      failure_reason: e.message,
+    }, e);
+
     process.exit(-1);
   } finally {
     cliProgressFooter.updateProgress();

--- a/src/libs/telemtry/cache-path.js
+++ b/src/libs/telemtry/cache-path.js
@@ -6,5 +6,5 @@ const os = require('os');
 module.exports = (() => {
   const resolvedHomeDir = os.homedir();
   if (!resolvedHomeDir) return null;
-  return path.resolve(resolvedHomeDir, '.serverless-tencent', 'telemtry-cache');
+  return path.resolve(resolvedHomeDir, '.serverless-tencent', 'telemetry-cache');
 })();


### PR DESCRIPTION
## What has been implemented?

Closes https://app.asana.com/0/0/1201933499900671/f

CLI will send a binary upgrade message to mixpanel(success and failure).

*failure* outcome:
- failure_step: 升级命令行
- failure_source: Serverless::CLI
---
<img width="1431" alt="Screen Shot 2022-03-09 at 14 26 05" src="https://user-images.githubusercontent.com/11454175/157386069-10e10704-e4c9-4dd5-b993-1d00d642fbc2.png">

