### PR TITLE
Purge latest-tag CDN when necessary

### DIFF
--- a/scripts/cdnWarmer/index.js
+++ b/scripts/cdnWarmer/index.js
@@ -3,7 +3,7 @@
  * Runs after publishing new version & every day regualrly
  * 1. Get latest version of binaries
  * 2. Warm them up
- * 
+ *
  * Ref
  * - https://console.intl.cloud.tencent.com/api/explorer?Product=cdn&Version=2018-06-06&Action=PurgeUrlsCache&SignVersion=
  * - https://console.intl.cloud.tencent.com/api/explorer?Product=cdn&Version=2018-06-06&Action=PushUrlsCache&SignVersion=
@@ -33,49 +33,48 @@ const client = new CdnClient(clientConfig);
 
 // eslint-disable-next-line new-cap
 client.PushUrlsCache({
-  Urls: [
-    `https://slt-binary-sv-1300963013.file.myqcloud.com/${version}/serverless-tencent-macos-x64`,
-    `https://slt-binary-sv-1300963013.file.myqcloud.com/${version}/serverless-tencent-macos-armv6`,
-    `https://slt-binary-sv-1300963013.file.myqcloud.com/${version}/serverless-tencent-linux`,
-    `https://slt-binary-sv-1300963013.file.myqcloud.com/${version}/serverless-tencent-win-x64`,
-  ],
-}).then(
-  (data) => {
-    console.log(data);
-    console.log(`${version} is warmed up successfully`);
-  },
-  (err) => {
-    console.error('error', err);
-    throw err;
-  }
-);
-
-// When the latest tag is outdated, we need to purge CDN cache
-got('https://slt-binary-sv-1300963013.file.myqcloud.com/latest-tag').then((res) => {
-  const CDNVersion = res.body;
-  if (CDNVersion.slice(1) !== version) {
-    console.log('CLI version tag on CDN is old, going to purge it')
-    // eslint-disable-next-line new-cap
-    return client.PurgeUrlsCache({
-      Urls: [
-        'https://slt-binary-sv-1300963013.file.myqcloud.com/latest-tag',
-      ],
-    })
-  }
-  console.log('CLI version tag is up to date, going to warm it')
-  // eslint-disable-next-line new-cap
-  return client.PushUrlsCache({
     Urls: [
-      'https://slt-binary-sv-1300963013.file.myqcloud.com/latest-tag',
+      `https://slt-binary-sv-1300963013.file.myqcloud.com/${version}/serverless-tencent-macos-x64`,
+      `https://slt-binary-sv-1300963013.file.myqcloud.com/${version}/serverless-tencent-macos-armv6`,
+      `https://slt-binary-sv-1300963013.file.myqcloud.com/${version}/serverless-tencent-linux`,
+      `https://slt-binary-sv-1300963013.file.myqcloud.com/${version}/serverless-tencent-win-x64`,
     ],
   })
-}).then(
-  (data) => {
-    console.log(data);
-    console.log('CLI version tag is purged/warmed up successfully');
-  },
-  (err) => {
-    console.error('error', err);
-    throw err;
-  }
-);
+  .then(
+    (data) => {
+      console.log(data);
+      console.log(`${version} is warmed up successfully`);
+    },
+    (err) => {
+      console.error('error', err);
+      throw err;
+    }
+  );
+
+// When the latest tag is outdated, we need to purge CDN cache
+got('https://slt-binary-sv-1300963013.file.myqcloud.com/latest-tag')
+  .then((res) => {
+    const CDNVersion = res.body;
+    if (CDNVersion.slice(1) !== version) {
+      console.log('CLI version tag on CDN is old, going to purge it');
+      // eslint-disable-next-line new-cap
+      return client.PurgeUrlsCache({
+        Urls: ['https://slt-binary-sv-1300963013.file.myqcloud.com/latest-tag'],
+      });
+    }
+    console.log('CLI version tag is up to date, going to warm it');
+    // eslint-disable-next-line new-cap
+    return client.PushUrlsCache({
+      Urls: ['https://slt-binary-sv-1300963013.file.myqcloud.com/latest-tag'],
+    });
+  })
+  .then(
+    (data) => {
+      console.log(data);
+      console.log('CLI version tag is purged/warmed up successfully');
+    },
+    (err) => {
+      console.error('error', err);
+      throw err;
+    }
+  );

--- a/scripts/cdnWarmer/index.js
+++ b/scripts/cdnWarmer/index.js
@@ -3,9 +3,14 @@
  * Runs after publishing new version & every day regualrly
  * 1. Get latest version of binaries
  * 2. Warm them up
+ * 
+ * Ref
+ * - https://console.intl.cloud.tencent.com/api/explorer?Product=cdn&Version=2018-06-06&Action=PurgeUrlsCache&SignVersion=
+ * - https://console.intl.cloud.tencent.com/api/explorer?Product=cdn&Version=2018-06-06&Action=PushUrlsCache&SignVersion=
  */
 const tencentcloud = require('tencentcloud-sdk-nodejs');
 const { version } = require('../../package.json');
+const got = require('got');
 
 console.log(`Going to warm up CDN for version ${version}`);
 
@@ -25,21 +30,49 @@ const clientConfig = {
 };
 
 const client = new CdnClient(clientConfig);
-const params = {
+
+// eslint-disable-next-line new-cap
+client.PushUrlsCache({
   Urls: [
-    'https://slt-binary-sv-1300963013.file.myqcloud.com/latest-tag',
     `https://slt-binary-sv-1300963013.file.myqcloud.com/${version}/serverless-tencent-macos-x64`,
     `https://slt-binary-sv-1300963013.file.myqcloud.com/${version}/serverless-tencent-macos-armv6`,
     `https://slt-binary-sv-1300963013.file.myqcloud.com/${version}/serverless-tencent-linux`,
     `https://slt-binary-sv-1300963013.file.myqcloud.com/${version}/serverless-tencent-win-x64`,
   ],
-};
-
-// eslint-disable-next-line new-cap
-client.PushUrlsCache(params).then(
+}).then(
   (data) => {
     console.log(data);
     console.log(`${version} is warmed up successfully`);
+  },
+  (err) => {
+    console.error('error', err);
+    throw err;
+  }
+);
+
+// When the latest tag is outdated, we need to purge CDN cache
+got('https://slt-binary-sv-1300963013.file.myqcloud.com/latest-tag').then((res) => {
+  const CDNVersion = res.body;
+  if (CDNVersion.slice(1) !== version) {
+    console.log('CLI version tag on CDN is old, going to purge it')
+    // eslint-disable-next-line new-cap
+    return client.PurgeUrlsCache({
+      Urls: [
+        'https://slt-binary-sv-1300963013.file.myqcloud.com/latest-tag',
+      ],
+    })
+  }
+  console.log('CLI version tag is up to date, going to warm it')
+  // eslint-disable-next-line new-cap
+  return client.PushUrlsCache({
+    Urls: [
+      'https://slt-binary-sv-1300963013.file.myqcloud.com/latest-tag',
+    ],
+  })
+}).then(
+  (data) => {
+    console.log(data);
+    console.log('CLI version tag is purged/warmed up successfully');
   },
   (err) => {
     console.error('error', err);

--- a/scripts/cdnWarmer/index.js
+++ b/scripts/cdnWarmer/index.js
@@ -39,6 +39,7 @@ client.PushUrlsCache({
       `https://slt-binary-sv-1300963013.file.myqcloud.com/${version}/serverless-tencent-linux`,
       `https://slt-binary-sv-1300963013.file.myqcloud.com/${version}/serverless-tencent-win-x64`,
     ],
+    Area: 'global',
   })
   .then(
     (data) => {
@@ -66,6 +67,7 @@ got('https://slt-binary-sv-1300963013.file.myqcloud.com/latest-tag')
     // eslint-disable-next-line new-cap
     return client.PushUrlsCache({
       Urls: ['https://slt-binary-sv-1300963013.file.myqcloud.com/latest-tag'],
+      Area: 'global',
     });
   })
   .then(


### PR DESCRIPTION
## What has been implemented?

When new CLI version is published, purge CDN to allow users to download latest version sooner

Ticket: https://app.asana.com/0/1200011502754281/1201925623133745