### PR TITLE
fix: Fix module require wrong path for invoke local on Windows

### DIFF
--- a/src/commands/invoke/invoke-local/runNode.js
+++ b/src/commands/invoke/invoke-local/runNode.js
@@ -14,7 +14,7 @@ module.exports = async (event, context, handlerFile, handlerFunc, cli) => {
   const tempNodeFileContent = `
 const fs = require('fs')
 const path = require('path')
-const { ${handlerFunc} } = require('${path.join(process.cwd(), handlerFile)}')
+const { ${handlerFunc} } = require(path.join(process.cwd(), '${handlerFile}'))
 
 async function test() {
 

--- a/src/commands/invoke/invoke-local/utils.js
+++ b/src/commands/invoke/invoke-local/utils.js
@@ -7,6 +7,11 @@ const { fileExistsSync } = require('../../../libs/utils');
 const chalk = require('chalk');
 const { execSync } = require('child_process');
 
+// If this process is called from standalone or npm script
+const isStandaloneExecutable = Boolean(
+  process.pkg && /^(?:\/snapshot\/|[A-Z]+:\\snapshot\\)/.test(__dirname)
+);
+
 const checkRuntime = (requiredRuntime, cli) => {
   if (!requiredRuntime) {
     throw new Error('必须指定所需要的运行时');
@@ -154,6 +159,14 @@ const summaryOptions = (config, instanceYml, cli) => {
   if (php) {
     process.env.INVOKE_LOCAL_PHP = php;
   }
+
+  if (isStandaloneExecutable && process.env.NODE_OPTIONS) {
+    delete process.env.NODE_OPTIONS;
+    colorLog(
+      'Binary 环境下不能添加环境变量 NODE_OPTIONS, 已自动删除。 如要在本地调试下使用此变量，请安装 npm 版本之后重新执行命令: npm i -g serverless-tencent'
+    );
+  }
+
   // Deal with scf component(single instance situation)
   if (component.startsWith('scf')) {
     const inputsHandler = inputs.handler || '';

--- a/src/libs/utils/basic.js
+++ b/src/libs/utils/basic.js
@@ -338,7 +338,11 @@ const loadInstanceConfigUncached = (directoryPath) => {
       if (e.name !== 'YAMLException') {
         throw e;
       } else {
-        throw new Error(`The serverless.yml file has incorrect format. Details: ${e.message}`);
+        const err = new Error(`serverless.yml 配置文件格式错误: ${e.message}`);
+        err.extraErrorInfo = {
+          referral: '', // TODO: Add yaml referral link
+        };
+        throw err;
       }
     }
   } else {


### PR DESCRIPTION
Closes:
1. [Windows环境下Node项目invoke local报错](https://app.asana.com/0/1200011502754281/1202067732141654/f): 对请求的module的在Windows环境下存在路径bug. https://github.com/serverless/serverless-tencent/discussions/180
2. [Binary运行环境下，在invoke local中忽略*NODE_OPTIONS*环境变量](https://app.asana.com/0/1200011502754281/1202068369054654/f)
3. [确认YAML格式的校验](https://app.asana.com/0/1200011502754281/1202067732141649/f)

## Todos

- [ ] 添加**YAML**格式的参考文档

---
yaml格式报错:
<img width="1532" alt="Screen Shot 2022-04-05 at 09 53 20" src="https://user-images.githubusercontent.com/11454175/161911971-37732707-ffbf-4224-8fcc-946482c54adc.png">

---
提醒用户忽略*NODE_OPTIONS*环境变量
<img width="1586" alt="Screen Shot 2022-04-06 at 15 35 14" src="https://user-images.githubusercontent.com/11454175/161920778-08e0539e-9b40-4050-bc14-608581ac8367.png">

