### PR TITLE
fix: add string for initializing on the template without app property

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -108,7 +108,7 @@ const initTemplateFromCli = async ({
 
   // For template with unspcified `app`, usually created by the community
   if (appName && !ymlParsed.app) {
-    ymlParsed.app = appName;
+    ymlParsed.app = `${appName}-${uuidv4().split('-')[0]}`;
     await saveYaml(serverlessFilePath, ymlParsed);
   }
 


### PR DESCRIPTION
## What has been implemented?

Closes https://app.asana.com/0/1200011502754281/1202165006943758/f

## Steps to verify

- install canary version: `npm i -g serverless-tencent@canary`
- `slt init nextjs-starter --demo demo`
- `cat demo/serverless.yml`, CLI will add random content after the *app* field

## Todos:

- [x] Write tests
- [x] Write / update documentation
- [x] Run Prettier
